### PR TITLE
Account for additional Gradle artifact api transform folders in gradle 5.1.1+

### DIFF
--- a/buildSrc/src/main/java/com/uber/okbuck/core/dependency/DependencyUtils.java
+++ b/buildSrc/src/main/java/com/uber/okbuck/core/dependency/DependencyUtils.java
@@ -66,10 +66,11 @@ public final class DependencyUtils {
 
   @SuppressWarnings("BooleanMethodIsAlwaysInverted")
   public static boolean isConsumable(File file) {
-    // Skip artifact files which are coming from the transformed folder.
-    // transforms-1 contains the contents of the resolved aar/jar and
+    // Skip artifact files coming from gradle artifact api transform folders.
+    // transforms-1, transforms-2 contain resolved aar/jar and
     // hence should not be consumed.
-    if (file.getAbsolutePath().contains("transforms-1/files-1")) {
+    if (file.getAbsolutePath().contains("transforms-1/files-1")
+            || file.getAbsolutePath().contains("transforms-2/files-2")) {
       return false;
     }
     return FilenameUtils.isExtension(file.getName(), ALLOWED_EXTENSIONS);


### PR DESCRIPTION
<!--
Thank you for contributing to okbuck. Before pressing the "Create Pull Request" button, please consider the following points.
Feel free to remove any irrelevant parts that you know are not related to the issue.
Any HTML comment like this will be stripped when rendering markdown, no need to delete them.
-->

<!-- Please give a description about what and why you are contributing, even if it's trivial. -->
**Description**:
`okbuck` skips artifacts coming from gradle artifact api transform folders (e.g. 
`~/.gradle/caches/transforms-1`)

`Gradle 5.1.1+` creates additional transform folders (`transform-2`) which should be skipped as well.

<!-- Please include the issue list number(s) or other PR numbers in the description if you are contributing in response to those. -->
**Related issue(s)**: https://github.com/uber/okbuck/issues/873